### PR TITLE
Fixed format for perturbation files in data/perturbations and added f…

### DIFF
--- a/data/perturbations/README.txt
+++ b/data/perturbations/README.txt
@@ -1,12 +1,39 @@
 # parse_perturbation_file
 
-Only take in 1 file using the option --pert_file_path
-File can have 1 or more perturbations
-(no warnings for wrong format or data as of now)
+Rules:
+Accepts 1 file at a time using the option --pert_file_path.
+File can have 1 or more perturbations.
+Each perturbation occupies 1 row.
+Tab-delimit different categories (e.g., lambda and 0 should be lambda\tab0).
+Separate by commas if items belong to the same category (e.g., lambda and mu should be lambda,mu).
 
-Each line of entry is converted to a dictionary
-Each dictionary is stored in a perturbations list
-The perturbations list is put into a list of treatments
+Headings can be in any order, as long as the values below match the headings.
+
+Headings can be in upper/lower/mixed cases.
+
+Headings' spelling can be “params”, “parameter”, “p” etc. (within reasonable variations)
+Same goes for “values”, “update_mode”, and “axes”.
+
+If a heading’s name cannot be recognized, an exception will be raised.
+For the perturbations files, rows under “parameters” and “values” now accept
+one or more inputs. If the number of parameters does not match the number of
+values, then an exception will be raised.
+
+If any required headings are missing, an exception will be raised.
+
+
+Algorithm:
+Each line of entry is put into a dictionary.
+Each dictionary is put into a perturbations list.
+The perturbations list is put into a list of treatments.
+
 
 EXAMPLE Format:
-params	lambda	0.005	update_mode	replace	axes	x	y	z
+parameters	values	update_mode	axes
+lambda	0	replace	x,y,z
+mu	0.8	add	x
+
+
+EXAMPLE Format:
+parameters	values	update_mode	axes
+lambda,mu	0.016,-0.08	replace	x

--- a/data/perturbations/add_x_mu_high.csv
+++ b/data/perturbations/add_x_mu_high.csv
@@ -1,1 +1,0 @@
-params	mu	0.8	update_mode	add	axes	x

--- a/data/perturbations/add_x_mu_high.tsv
+++ b/data/perturbations/add_x_mu_high.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+mu	0.8	add	x

--- a/data/perturbations/all_perturbations.tsv
+++ b/data/perturbations/all_perturbations.tsv
@@ -1,17 +1,18 @@
-params	lambda	0.005	update_mode	replace	axes	x	y	z
-params	lambda	0.080	update_mode	replace	axes	z	y	
-params	lambda	0.160	update_mode	replace	axes	y		
-params	lambda	0.000	update_mode	replace	axes	x	y	z
-params	mu	-0.800	update_mode	replace	axes	x		
-params	delta	2.000	update_mode	multiply	axes	x	y	z
-params	delta	2.000	update_mode	multiply	axes	z		
-params	mu	-0.800	update_mode	replace	axes	x	y	z
-params	mu	0.800	update_mode	replace	axes	x	y	z
-params	mu	0.800	update_mode	add	axes	x		
-params	mu	0.800	update_mode	replace	axes	x		
-params	lambda	0.008	mu	-0.08	update_mode	replace	axes	x
-params	lambda	0.016	mu	-0.08	update_mode	replace	axes	x
-params	lambda	0.064	update_mode	replace	axes	x		
-params	lambda	0.064	update_mode	replace	axes	z	y	
-params	lambda	0.064	update_mode	replace	axes	y		
-params	lambda	0.000	update_mode	replace	axes	z		
+parameters	values	update_mode	axes
+lambda	0.005	replace	x,y,z
+lambda	0.08	replace	z,y
+lambda	0.16	replace	y
+lambda	0	replace	x,y,z
+mu	-0.8	replace	x
+delta	2	multiply	x,y,z
+delta	2	multiply	z
+mu	-0.8	replace	x,y,z
+mu	0.8	replace	x,y,z
+mu	0.8	add	x
+mu	0.8	replace	x
+lambda,mu	0.008,-0.08	replace	x
+lambda,mu	0.016,-0.08	replace	x
+lambda	0.064	replace	x
+lambda	0.064	replace	z,y
+lambda	0.064	replace	y
+lambda	0	replace	z

--- a/data/perturbations/double_xyz_delta.csv
+++ b/data/perturbations/double_xyz_delta.csv
@@ -1,1 +1,0 @@
-params	delta	2	update_mode	multiply	axes	x	y	z

--- a/data/perturbations/double_xyz_delta.tsv
+++ b/data/perturbations/double_xyz_delta.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+delta	2	multiply	x,y,z

--- a/data/perturbations/double_z_delta.csv
+++ b/data/perturbations/double_z_delta.csv
@@ -1,1 +1,0 @@
-params	delta	2	update_mode	multiply	axes	z

--- a/data/perturbations/double_z_delta.tsv
+++ b/data/perturbations/double_z_delta.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+delta	2	multiply	z

--- a/data/perturbations/set_x_lambda_high.csv
+++ b/data/perturbations/set_x_lambda_high.csv
@@ -1,1 +1,0 @@
-params	lambda	0.064	update_mode	replace	axes	x

--- a/data/perturbations/set_x_lambda_high.tsv
+++ b/data/perturbations/set_x_lambda_high.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0.064	replace	x

--- a/data/perturbations/set_x_lambda_medium.csv
+++ b/data/perturbations/set_x_lambda_medium.csv
@@ -1,1 +1,0 @@
-params	lambda	0.016	mu	-0.08	update_mode	replace	axes	x

--- a/data/perturbations/set_x_lambda_medium.tsv
+++ b/data/perturbations/set_x_lambda_medium.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda,mu	0.016,-0.08	replace	x

--- a/data/perturbations/set_x_lambda_small.csv
+++ b/data/perturbations/set_x_lambda_small.csv
@@ -1,1 +1,0 @@
-params	lambda	0.008	mu	-0.08	update_mode	replace	axes	x

--- a/data/perturbations/set_x_lambda_small.tsv
+++ b/data/perturbations/set_x_lambda_small.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda,mu	0.008,-0.08	replace	x

--- a/data/perturbations/set_x_mu_high.csv
+++ b/data/perturbations/set_x_mu_high.csv
@@ -1,1 +1,0 @@
-params	mu	0.8	update_mode	replace	axes	x

--- a/data/perturbations/set_x_mu_high.tsv
+++ b/data/perturbations/set_x_mu_high.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+mu	0.8	replace	x

--- a/data/perturbations/set_x_mu_low.tsv
+++ b/data/perturbations/set_x_mu_low.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+mu	-0.8	replace	x

--- a/data/perturbations/set_xyz_lambda_low.tsv
+++ b/data/perturbations/set_xyz_lambda_low.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0.005	replace	x,y,z

--- a/data/perturbations/set_xyz_lambda_zero.tsv
+++ b/data/perturbations/set_xyz_lambda_zero.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0	replace	x,y,z

--- a/data/perturbations/set_xyz_mu_high.csv
+++ b/data/perturbations/set_xyz_mu_high.csv
@@ -1,1 +1,0 @@
-params	mu	0.8	update_mode	replace	axes	x	y	z

--- a/data/perturbations/set_xyz_mu_high.tsv
+++ b/data/perturbations/set_xyz_mu_high.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+mu	0.8	replace	x,y,z

--- a/data/perturbations/set_xyz_mu_low.csv
+++ b/data/perturbations/set_xyz_mu_low.csv
@@ -1,1 +1,0 @@
-params	mu	-0.8	update_mode	replace	axes	x	y	z

--- a/data/perturbations/set_xyz_mu_low.tsv
+++ b/data/perturbations/set_xyz_mu_low.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+mu	-0.8	replace	x,y,z

--- a/data/perturbations/set_y_lambda_high.csv
+++ b/data/perturbations/set_y_lambda_high.csv
@@ -1,1 +1,0 @@
-params	lambda	0.064	update_mode	replace	axes	y

--- a/data/perturbations/set_y_lambda_high.tsv
+++ b/data/perturbations/set_y_lambda_high.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0.064	replace	y

--- a/data/perturbations/set_y_lambda_medium.tsv
+++ b/data/perturbations/set_y_lambda_medium.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0.16	replace	y

--- a/data/perturbations/set_yz_lambda_high.csv
+++ b/data/perturbations/set_yz_lambda_high.csv
@@ -1,1 +1,0 @@
-params	lambda	0.064	update_mode	replace	axes	z	y

--- a/data/perturbations/set_yz_lambda_high.tsv
+++ b/data/perturbations/set_yz_lambda_high.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0.064	replace	z,y

--- a/data/perturbations/set_yz_lambda_medium.tsv
+++ b/data/perturbations/set_yz_lambda_medium.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0.08	replace	z,y

--- a/data/perturbations/set_z_lambda_zero.csv
+++ b/data/perturbations/set_z_lambda_zero.csv
@@ -1,1 +1,0 @@
-params	lambda	0	update_mode	replace	axes	z

--- a/data/perturbations/set_z_lambda_zero.tsv
+++ b/data/perturbations/set_z_lambda_zero.tsv
@@ -1,0 +1,2 @@
+parameters	values	update_mode	axes
+lambda	0	replace	z

--- a/data/perturbations/x_mu_low.csv
+++ b/data/perturbations/x_mu_low.csv
@@ -1,1 +1,0 @@
-params	mu	-0.8	update_mode	replace	axes	x

--- a/data/perturbations/xyz_lambda_low.csv
+++ b/data/perturbations/xyz_lambda_low.csv
@@ -1,1 +1,0 @@
-params	lambda	0.005	update_mode	replace	axes	x	y	z

--- a/data/perturbations/xyz_lambda_zero.csv
+++ b/data/perturbations/xyz_lambda_zero.csv
@@ -1,1 +1,0 @@
-params	lambda	0	update_mode	replace	axes	x	y	z

--- a/data/perturbations/xyz_lambda_zero_alt_format.csv
+++ b/data/perturbations/xyz_lambda_zero_alt_format.csv
@@ -1,2 +1,0 @@
-#parameter	value	update_mode	axes
-lambda	0	replace	x,y,z

--- a/data/perturbations/y_lambda_medium.csv
+++ b/data/perturbations/y_lambda_medium.csv
@@ -1,1 +1,0 @@
-params	lambda	0.16	update_mode	replace	axes	y

--- a/data/perturbations/yz_lambda_medium.csv
+++ b/data/perturbations/yz_lambda_medium.csv
@@ -1,1 +1,0 @@
-params	lambda	0.08	update_mode	replace	axes	z	y

--- a/karenina/spatial_ornstein_uhlenbeck.py
+++ b/karenina/spatial_ornstein_uhlenbeck.py
@@ -16,6 +16,7 @@ from optparse import OptionParser
 from optparse import OptionGroup
 from os.path import join,isdir,realpath,dirname
 from os import makedirs
+import pandas as pd
 
 
 def make_option_parser():
@@ -40,7 +41,7 @@ def make_option_parser():
 
     optional_options.add_option('--pert_file_path',\
       default = join(dirname(dirname(realpath(__file__))),'data',\
-      'perturbations','xyz_lambda_zero.csv'),\
+      'perturbations','set_xyz_lambda_zero.tsv'),\
       type = "string",\
       help = 'file path to a perturbation file specifying parameters for' +
       ' the simulation results [default: %default]')
@@ -138,7 +139,7 @@ def write_options_to_log(log, opts):
 
 def parse_perturbation_file(opts):
     """Return a list of perturbations
-    infile -- a .csv file describing one perturbation per line
+    infile -- a .tsv file describing one perturbation per line
     assume input file is correctly formatted (no warnings if not)
 
     NOTE: each pertubation should be in the format:
@@ -149,49 +150,75 @@ def parse_perturbation_file(opts):
       "update_mode":"replace",\
       "axes":["x","y","z"]}
     """
-    perturb_list = []
+
+    perturbations_list = []
+
     if (opts.pert_file_path != None):
-        input_file = open(opts.pert_file_path, "r")
+        df = pd.read_csv(opts.pert_file_path, sep = "\t")
 
-        for line in input_file:
-            print (line)
-            temp_list = []
+        headers_list = list(df)
 
-            for word in line.split('\t'):
-                temp_list.append(word)
+        for index, row in df.iterrows():
 
-            temp_dict = {"start":opts.perturbation_timepoint,\
-              "end":opts.perturbation_timepoint + opts.perturbation_duration}
+            a_perturbation = {"start":opts.perturbation_timepoint,\
+            "end":opts.perturbation_timepoint + opts.perturbation_duration}
 
-            for temp_list_index in range(len(temp_list)):
-                if (temp_list[temp_list_index] == 'params'):
-                    index = temp_list_index + 1
-                    temp_dict['params'] = {}
-                    while (temp_list[index] != 'update_mode'):
-                        temp_dict['params'][temp_list[index]] =\
-                        float(temp_list[index + 1])
-                        index += 2
-                elif (temp_list[temp_list_index] == 'update_mode'):
-                    temp_dict["update_mode"] = temp_list[temp_list_index + 1]
-                elif (temp_list[temp_list_index] == 'axes'):
-                    index = temp_list_index + 1;
-                    temp_dict["axes"] = []
-                    while (index != len(temp_list) and temp_list[index] != ''
-                    and temp_list[index] != '\n'):
-                        split = temp_list[index].split('\n')
-                        temp_dict["axes"].append(split[0])
-                        index += 1
-            perturb_list.append(temp_dict)
-        input_file.close()
+            params_checker = False
+            values_checker = False
+            update_mode_checker = False
+            axes_checker = False
+
+            for header in headers_list:
+
+                header_lowercase = header.lower()
+
+                if header_lowercase in ("parameter", "parameters", "param",\
+                "params", "p"):
+                    params_checker = True
+                    params = row[header].split(",")
+
+                elif header_lowercase in ("value", "values", "val", "vals",\
+                "v"):
+                    values_checker = True
+                    values = str(row[header]).split(",")
+
+                elif header_lowercase in ("update_mode", "update_modes",\
+                "update mode", "update modes", "u", "um", "u_m", "u m"):
+                    update_mode_checker = True
+                    update_mode = row[header]
+
+                elif header_lowercase in ("axes", "axis", "a"):
+                    axes_checker = True
+                    axes = row[header].split(",")
+
+                else:
+                    raise ValueError("Could not identify header name in " + \
+                    "perturbations file")
+
+            if (params_checker == False or values_checker == False or \
+            update_mode_checker == False or axes_checker == False):
+                raise ValueError("Missing header(s)")
+
+            if len(params) != len(values):
+                raise ValueError("Number of parameters does not match the " + \
+                "number of values")
+
+            a_perturbation["params"] = {}
+            for idx, single_param in enumerate(params):
+                a_perturbation["params"][single_param] = float(values[idx])
+            a_perturbation["update_mode"] = update_mode
+            a_perturbation["axes"] = axes
+
+            perturbations_list.append(a_perturbation)
 
     else:
         set_xyz_lambda_zero = {"start":opts.perturbation_timepoint,\
         "end":opts.perturbation_timepoint + opts.perturbation_duration,\
         "params":{"lambda":0.000},"update_mode":"replace","axes":["x","y","z"]}
 
-        perturb_list.append(set_xyz_lambda_zero)
+        perturbations_list.append(set_xyz_lambda_zero)
 
-    return perturb_list
+    return perturbations_list
 
 
 def main():


### PR DESCRIPTION
…unctionalities to allow for more varied perturbation files format.

# parse_perturbation_file

Rules:
Accepts 1 file at a time using the option --pert_file_path.
File can have 1 or more perturbations.
Each perturbation occupies 1 row.
Tab-delimit different categories (e.g., lambda and 0 should be lambda\tab0).
Separate by commas if items belong to the same category (e.g., lambda and mu should be lambda,mu).

Headings can be in any order, as long as the values below match the headings.

Headings can be in upper/lower/mixed cases.

Headings' spelling can be “params”, “parameter”, “p” etc. (within reasonable variations)
Same goes for “values”, “update_mode”, and “axes”.

If a heading’s name cannot be recognized, an exception will be raised.
For the perturbations files, rows under “parameters” and “values” now accept
one or more inputs. If the number of parameters does not match the number of
values, then an exception will be raised.

If any required headings are missing, an exception will be raised.


Algorithm:
Each line of entry is put into a dictionary.
Each dictionary is put into a perturbations list.
The perturbations list is put into a list of treatments.


EXAMPLE Format:
parameters	values	update_mode	axes
lambda	0	replace	x,y,z
mu	0.8	add	x


EXAMPLE Format:
parameters	values	update_mode	axes
lambda,mu	0.016,-0.08	replace	x
